### PR TITLE
fix: resource loading from root path

### DIFF
--- a/index.html
+++ b/index.html
@@ -224,7 +224,7 @@ Draw mode:  http://maps.com/?__draw=1
 
       var vectorLayer = new ol.layer.Vector({
         source: new ol.source.Vector({
-          url: 'assets/data.geojson',
+          url: './assets/data.geojson',
           format: new ol.format.GeoJSON(),
           wrapX: false,
         }),
@@ -539,12 +539,12 @@ Draw mode:  http://maps.com/?__draw=1
 
           recognition.onstart = function () {
             recognizing = true;
-            $(that).css('backgroundImage', 'url(assets/images/501cyan.png)');
+            $(that).css('backgroundImage', 'url(./assets/images/501cyan.png)');
             $(that).parent().find('input').val('...');
           };
           recognition.onend = function () {
             recognizing = false;
-            $(that).css('backgroundImage', 'url(assets/images/501black.png)');
+            $(that).css('backgroundImage', 'url(./assets/images/501black.png)');
           };
 
           recognition.onresult = function (event) {


### PR DESCRIPTION
- Add ./ prefix to assets/data.geojson to ensure proper loading
- Fix voice search image paths (501cyan.png, 501black.png) with ./ prefix
- Ensures all resources load correctly from https://duyet.github.io/shtp-maps/

## Summary by Sourcery

Ensure proper loading of map data and voice search icons by prefixing asset URLs with './' in index.html

Bug Fixes:
- Prefix the GeoJSON data URL with './' for correct vector layer loading
- Prefix the voice search icon URLs with './' to fix their loading