### PR TITLE
fix: resource loading path for GitHub Pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,6 +11,7 @@ Draw mode:  http://maps.com/?__draw=1
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <base href="/shtp-maps/" />
     <title>IS-Map</title>
     <link
       rel="stylesheet"


### PR DESCRIPTION
Add <base href="/shtp-maps/"> to ensure all relative resource paths resolve correctly from the subdirectory. This fixes resources loading from https://duyet.github.io/ instead of https://duyet.github.io/shtp-maps/

## Summary by Sourcery

Bug Fixes:
- Fix relative resource paths by setting base href to /shtp-maps/ in index.html