### PR TITLE
fix: SHTP Maps 404 error

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,8 +11,7 @@ Draw mode:  http://maps.com/?__draw=1
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width,initial-scale=1" />
-    <base href="/shtp-maps/" />
-    <title>IS-Map</title>
+    <title>SHTP Maps</title>
     <link
       rel="stylesheet"
       type="text/css"

--- a/vite.config.js
+++ b/vite.config.js
@@ -7,6 +7,7 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
 export default defineConfig({
+    base: '/shtp-maps/',
     root: '.',
     publicDir: 'assets',
     build: {


### PR DESCRIPTION
- Remove hardcoded <base> tag from index.html that was causing 404s
- Configure Vite base path for GitHub Pages deployment
- Change title from 'IS-Map' to 'SHTP Maps'

The hardcoded base tag was preventing resources from loading correctly during local development. Vite now handles the base path automatically during build, ensuring resources load correctly both locally and on GitHub Pages.